### PR TITLE
Improve server side state management

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
+import os
 from llmgame import create_app
 
 app = create_app()
+
+app.secret_key = os.getenv("APP_SECRET_KEY")
 
 if __name__ == '__main__':
     app.run()

--- a/llmgame/llmgame.py
+++ b/llmgame/llmgame.py
@@ -16,8 +16,8 @@ from langchain_core.exceptions import OutputParserException
 
 bp = Blueprint('llmgame', __name__)
 
-OLLAMAURL = "http://localhost:11434"
-# OLLAMAURL = "https://carlollama.victoriousflower-d746971e.uksouth.azurecontainerapps.io"
+# OLLAMAURL = "http://localhost:11434"
+OLLAMAURL = "https://carlollama.victoriousflower-d746971e.uksouth.azurecontainerapps.io"
 OLLAMAMODEL = "mistral"
 # Flag to query different LLM. If False, it will use OpenAI API
 OFFLINE = True

--- a/llmgame/llmgame.py
+++ b/llmgame/llmgame.py
@@ -54,7 +54,8 @@ def welcome():
         init_session_variables()
         session['name'] = name
         
-        topics = generate_topics()        
+        topics = generate_topics()
+        session['topics'] = topics     
 
         return render_template('main.html',
                                name=name,
@@ -98,7 +99,15 @@ def display_surprise():
         session['selectedtopic'] = topic
         return topic
 
-    return render_template('surprise.html', 
+    # make sure topics have been genereted in POST request and
+    # the player has not seen the question already
+    if not session['topics']:
+        session['end'] = True
+        session['question'] = None
+        return render_template('error.html', 
+                        errorMessage="That's not how you are supposed to play the game! Try again.")
+    else:
+        return render_template('surprise.html', 
                            topic=session['selectedtopic']) 
 
 
@@ -129,7 +138,7 @@ def display_question():
         session['options'] = options
         return question
 
-    if session['question'] is None:
+    if session['question'] is None or session['end']:
         return render_template('error.html', 
                                 errorMessage="Something went wrong!")
     return render_template('question.html', 

--- a/llmgame/llmgame.py
+++ b/llmgame/llmgame.py
@@ -109,6 +109,8 @@ def display_question():
         selected_topic = request.get_json()
         # Set up the question based on the topic
         session['selectedtopic'] = selected_topic
+        # empty list to prevent unapproved behaviours
+        session['topics'] = []
         question = None
         attempts = 0
         while question is None and attempts < 3:
@@ -127,18 +129,14 @@ def display_question():
         session['options'] = options
         return question
 
-    if not session['end']:
-        if session['question'] is None:
-            return render_template('error.html', 
-                                   errorMessage="Something went wrong!")
-        return render_template('question.html', 
-                            question=session['question'], 
-                            options=session['options'],
-                            current_question=session['index'],
-                            lifelines=session['lifelines'])
-    else:
-        # show game over message
-        return redirect(url_for('llmgame.game_over')) 
+    if session['question'] is None:
+        return render_template('error.html', 
+                                errorMessage="Something went wrong!")
+    return render_template('question.html', 
+                        question=session['question'], 
+                        options=session['options'],
+                        current_question=session['index'],
+                        lifelines=session['lifelines'])
 
 
 @bp.route('/topics', methods=('GET', 'POST'))
@@ -168,8 +166,10 @@ def next_question():
         else:
             # make sure topics have been genereted in POST request above and stored in session
             if not session['topics']:
-                # show game over message
-                return redirect(url_for('llmgame.game_over'))
+                session['end'] = True
+                session['question'] = None
+                return render_template('error.html', 
+                                errorMessage="That's not how you are supposed to play the game! Try again.")
             else:
                 return render_template('main.html',
                                     name=session['name'],

--- a/llmgame/llmgame.py
+++ b/llmgame/llmgame.py
@@ -47,19 +47,17 @@ def welcome():
     for the first question"""
     if request.method == 'POST':
         name = request.form['name']
-
+        # set default name if none is given
         if not name:
             name = 'Player'
-
         init_session_variables()
         session['name'] = name
-        
-        topics = generate_topics()
-        session['topics'] = topics     
+        # generate new topics and store them in session object
+        session['topics'] = generate_topics()  
 
         return render_template('main.html',
-                               name=name,
-                               topics=topics)
+                               name=session['name'],
+                               topics=session['topics'])
     
     return render_template('welcome.html')
 
@@ -161,11 +159,11 @@ def next_question():
             # check if a wrong answer has been submitted AND
             # make sure the question index is equal to the number of answers given
             if not session['end'] and session['index'] == len(session['answers']):
+                # progress to next question
                 session['index'] += 1
-
-                topics = generate_topics()
-                session['topics'] = topics
-                return topics   
+                # generate new topics and store them in session object
+                session['topics'] = generate_topics()
+                return session['topics']   
             else:
                 # show game over message
                 return Response(

--- a/llmgame/templates/error.html
+++ b/llmgame/templates/error.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{% block header %}
+    <div class="container">
+        <h1>Error</h1>
+        <p>{{errorMessage}}</p>
+
+        <button id="tryButton">Start Over</button>
+    </div>
+    <script>
+        $('#tryButton').click(function() {
+            window.location.href="{{ url_for( 'llmgame.index' ) }}";
+        });
+    </script>
+{% endblock %}

--- a/llmgame/templates/question.html
+++ b/llmgame/templates/question.html
@@ -73,6 +73,9 @@
         setCurrentQuestion(questionItems[Number({{current_question}}) - 1]);
 
         document.getElementById('next-button').addEventListener('click', function(event) {
+            // show loader
+            document.getElementById('loader').style.display = 'block';
+
             // Disable the button immediately and update its text
             const submitButton = document.getElementById('next-button');
             submitButton.disabled = true;
@@ -89,9 +92,11 @@
                 .then(data => {
                     if (data == "error") {
                         // Handle error (e.g., user tried to cheat)
-                        // alert(data);
                         // ... redirect or reset ...
-                        window.location.href = "{{ url_for('llmgame.game_over') }}";
+
+                        // since question in the session object has been cleared
+                        // the GET request to /question will show the error page
+                        window.location.href = "{{ url_for('llmgame.display_question') }}";
                     } else {
                         window.location.href = "{{ url_for('llmgame.next_question') }}";
                     }

--- a/llmgame/templates/question.html
+++ b/llmgame/templates/question.html
@@ -72,10 +72,30 @@
 
         setCurrentQuestion(questionItems[Number({{current_question}}) - 1]);
 
-        $('#next-button').click(function() {
-            document.getElementById('loader').style.display = 'block';
+        document.getElementById('next-button').addEventListener('click', function(event) {
+            // Disable the button immediately and update its text
+            const submitButton = document.getElementById('next-button');
+            submitButton.disabled = true;
+            submitButton.innerHTML = "...";
+            submitButton.style.pointerEvents = 'none';
 
-            window.location.href="{{ url_for( 'llmgame.next_question' ) }}";
+            const topics_url = {{ url_for('llmgame.next_question')|tojson }};
+            fetch(topics_url, {
+                    "method": "POST",
+                    "headers": {"Content-Type": "application/json"},
+                    "body": JSON.stringify("next"),
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data == "error") {
+                        // Handle error (e.g., user tried to cheat)
+                        // alert(data);
+                        // ... redirect or reset ...
+                        window.location.href = "{{ url_for('llmgame.game_over') }}";
+                    } else {
+                        window.location.href = "{{ url_for('llmgame.next_question') }}";
+                    }
+                });
         });
 
         $('#quit-button').click(function() {

--- a/llmgame/templates/surprise.html
+++ b/llmgame/templates/surprise.html
@@ -10,8 +10,15 @@
     </div>
 
     <script>
-        $('#continueButton').click(function() {
+        document.getElementById('continueButton').addEventListener('click', function(event) {
+            // show loader
             document.getElementById('loader').style.display = 'block';
+
+            // Disable the button immediately and update its text
+            const submitButton = document.getElementById('continueButton');
+            submitButton.disabled = true;
+            submitButton.innerHTML = "Generating...";
+            submitButton.style.pointerEvents = 'none';
             
             let selTopic = "{{topic|safe}}";
             console.log(selTopic);

--- a/llmgame/templates/welcome.html
+++ b/llmgame/templates/welcome.html
@@ -4,18 +4,23 @@
     <div class="container" id="welcomePage"> 
         <h1>Welcome, Challenger!</h1>
         <p>Enter your name to embark on this quizzing quest:</p>
-        <form method="post">
+        <form id="myForm" method="post">
             <input type="text" id="name" name="name" placeholder="Your Name" value="{{ request.form['name'] }}">
             <button id="continueButton">Continue</button>
         </form>
     </div>
 
     <script>
-         $("#continueButton").click(function() {
+        document.getElementById('myForm').addEventListener('submit', function(event) {
+            // show loader
             document.getElementById('loader').style.display = 'block';
+
+            // Disable the button immediately and update its text
+            const submitButton = document.getElementById('continueButton');
+            submitButton.disabled = true;
+            submitButton.innerHTML = "Generating...";
         });
 
-        // Future code to handle clicking 'continueButton' 
     </script>
 {% endblock %}
 

--- a/llmgame/templates/welcome.html
+++ b/llmgame/templates/welcome.html
@@ -19,6 +19,7 @@
             const submitButton = document.getElementById('continueButton');
             submitButton.disabled = true;
             submitButton.innerHTML = "Generating...";
+            submitButton.style.pointerEvents = 'none';
         });
 
     </script>


### PR DESCRIPTION
This PR prevents multiple requests to LLM when using browser's back and forward buttons.

Additionally, it stops a few different ways of cheating by going back to the previous page and:
- Selecting a new topic
- Generating a new question

Closing #8 