### PR TITLE
Handle model not found

### DIFF
--- a/llmgame/llmgame.py
+++ b/llmgame/llmgame.py
@@ -217,7 +217,12 @@ def generate_topics():
         model = ChatOpenAI(model="gpt-4", temperature=0.8)
     chain = prompt | model | output_parser
     
-    llm_response = chain.invoke({"instruction": instruction})
+    try:
+        llm_response = chain.invoke({"instruction": instruction})        
+    except Exception as e:
+        print(e)
+        return None
+        
     if llm_response != "" and llm_response is not None:
         print (llm_response)
         if "topics" in llm_response:
@@ -257,8 +262,13 @@ def generate_random_topic(topics: list):
     else:
         model = ChatOpenAI(model="gpt-4", temperature=0.8)
     chain = prompt | model | output_parser
-    
-    llm_response = chain.invoke({"instruction": instruction})
+
+    try:
+        llm_response = chain.invoke({"instruction": instruction})        
+    except Exception as e:
+        print(e)
+        return None
+
     if llm_response != "" and llm_response is not None:
         print(llm_response)
         if "topic" in llm_response:
@@ -338,7 +348,10 @@ Make sure the answer is among the list of options. \
         return None, None, None
     except OutputParserException:
         print("Failed to generate a question - (parsing LLM response)")
-        return None, None, None
+        return None, None, None       
+    except Exception as e:
+        print(e)
+        return None, None, None 
     
 
 @bp.route('/check_answer', methods=['POST'])

--- a/llmgame/templates/main.html
+++ b/llmgame/templates/main.html
@@ -40,10 +40,13 @@
                         "method": "POST",
                         "headers": {"Content-Type": "application/json"},
                         "body": JSON.stringify(topics),
-                    }).then((response) => {
-                        console.log(response);
-                    }).then((html) => {
-                        window.location.href = "{{ url_for('llmgame.display_surprise') }}";
+                    }).then(response => response.json())
+                    .then((data) => {
+                        if(data.status == 200)
+                            window.location.href = "{{ url_for('llmgame.display_surprise') }}";
+                        else {
+                            window.location.assign("/error/" + data.data);
+                        }
                     });
             }
             else {
@@ -52,10 +55,13 @@
                         "method": "POST",
                         "headers": {"Content-Type": "application/json"},
                         "body": JSON.stringify(selTopic),
-                    }).then((response) => {
-                        console.log(response);
-                    }).then((html) => {
-                        window.location.href = "{{ url_for('llmgame.display_question') }}";
+                    }).then(response => response.json())
+                    .then((data) => {
+                        if(data.status == 200)
+                            window.location.href = "{{ url_for('llmgame.display_question') }}";
+                        else {
+                            window.location.assign("/error/" + data.data);
+                        }
                     });
             }
         });

--- a/llmgame/templates/question.html
+++ b/llmgame/templates/question.html
@@ -90,15 +90,19 @@
                 })
                 .then(response => response.json())
                 .then(data => {
-                    if (data == "error") {
-                        // Handle error (e.g., user tried to cheat)
-                        // ... redirect or reset ...
-
-                        // since question in the session object has been cleared
-                        // the GET request to /question will show the error page
-                        window.location.href = "{{ url_for('llmgame.display_question') }}";
-                    } else {
+                    if(data.status == 200)
                         window.location.href = "{{ url_for('llmgame.next_question') }}";
+                    else {
+                        if(data.status == 400){
+                            // Handle error (e.g., user tried to cheat)
+                            // ... redirect or reset ...
+
+                            // since question in the session object has been cleared
+                            // the GET request to /question will show the error page
+                            window.location.href = "{{ url_for('llmgame.display_question') }}";
+                        } else{ 
+                            window.location.assign("/error/" + data.data);
+                        }
                     }
                 });
         });


### PR DESCRIPTION
This PR addresses the cases when the model is not available (for example because of a typo in the name or the model has not been pulled). This caused a 404 error when trying to generate the topics or question.

NOTE: at the moment, the name of the model (OLLAMAURL) is hardcoded.

Try except blocks have been added to handle exceptions here:

```python
llm_response = chain.invoke({"instruction": instruction})
```

If an exception is raised, it will return None bacause the model has not been found.

Furthermore, the /error endpoint has been added, which takes a string parameter (msg) to then render the error page with the flexibility of showing different error messages. 

This allows the following code to be used directly in JavaScript;

```javascript
window.location.assign("/error/" + data.data);
```

Where `data.data` represent the error message returned from one of the POST requests to generate topics, surprise or question.
`data` is the JSON object returned from the endpoints. Examples:

```python
return {
    "status": 500,
    "data": "AI model is offline! Try again later."
}
return {
    "status": 200,
    "data": question
}
```
The first JSON object is returned when None is returned from content generation, ie. from `generate_topics()` , otherwise the JSON object will have a 200 status code and the generated content assigned to the 'data' key.

This way POST requests can be better handled and an appropriate view will always be displayed according to the response.


Closing #12 